### PR TITLE
Add title_options method for when there are no translations

### DIFF
--- a/lib/enum.rb
+++ b/lib/enum.rb
@@ -41,6 +41,10 @@ class Enum
     Hash[map { |ev| [ev.t, ev.name] }]
   end
 
+  def title_options
+    Hash[map { |ev| [ev.name.to_s.titleize, ev.value] }]
+  end
+
   private
   def map_hash(hash)
     @by_name = {}


### PR DESCRIPTION
I sometimes use enums only in admin sections where I can assume a language. I generally just name my enums well enough that a simple titleize on the enum name will work just fine. Rather than having to define translations, I added a tiny method that would allow me to use the names in a select box.
