### PR TITLE
Add value_options - for use with FormBuilder.select

### DIFF
--- a/lib/enum.rb
+++ b/lib/enum.rb
@@ -46,6 +46,10 @@ class Enum
     Hash[map { |ev| [ev.t, ev.name] }]
   end
 
+  def value_options
+    Hash[map { |ev| [ev.t, ev.value]}]
+  end
+
   private
   def map_hash(hash)
     @by_name = {}


### PR DESCRIPTION
This adds one more method to enums, with a slightly different options array. This should allow us to supply a hash which will not only work with `options_for_select` but also Rails's FormBuilder. Because the enums are really saved in the database as values, not keys, using the name as the option key causes it not to realize which one is selected.
