### PR TITLE
fix a bug of rails trying to use to_ary function.

### DIFF
--- a/lib/enum/enum_value.rb
+++ b/lib/enum/enum_value.rb
@@ -92,6 +92,10 @@ class Enum::EnumValue < BasicObject
     end
   end
 
+  def respond_to_missing?(method, *)
+    method.to_s == 'to_ary' ? false : super
+  end
+
   private
   def const_to_translation(name)
     # From Rails' ActiveSupport String#underscore


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/5759
There is no to_ary function for Enum::EnumValue, but it does respond to to_ary calls with method_missing.
For example, `[STATUSES.some_enum_status].flatten` will fail on `undefined method 'to_ary'`.
So this is meant to indicate rails to not use to_ary on this object.

Was tested on 
Rails 4.2.11 + Ruby 2.3.8